### PR TITLE
Url fix branch

### DIFF
--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -9,27 +9,22 @@ import { AppTab } from '../../types/tab.type';
 const Popup = () => {
   const [tabs, setTabs] = useState<AppTab[]>([]);
   const [repo, setRepo] = useState(getRepoNameFromStorage());
-  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>(new Set(""));
+  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>(new Set());
 
   const getTabs = useCallback(async () => {
     const tabs = await chrome.tabs.query({
       url: ['https://github.com/*/pull/*/files'],
     }) as AppTab[];
     console.log({ tabs });
-    const filteredTabs = tabs.filter((tab: AppTab) => {
-      console.log(uniqueUrls);
-      if(uniqueUrls!.has(tab.url!)){
+    const filteredTabs = tabs
+    .filter((tab: AppTab) => {
+      if(uniqueUrls && uniqueUrls.has(tab.url!)){
         return false;
       }
       setUniqueUrls(uniqueUrls.add(tab.url!));
-      return true;
-    })
-    .filter((tab: AppTab) => {
       if (!repo) {
         return true;
       }
-      setUniqueUrls(new Set<string>(uniqueUrls!.add(tab.url!)));
-      console.log(`unique urls are: ${uniqueUrls}`)
       return tab.url!.toLowerCase().includes(repo.toLowerCase());
     }).map(tabItem => ({
       ...tabItem,

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -9,7 +9,7 @@ import { AppTab } from '../../types/tab.type';
 const Popup = () => {
   const [tabs, setTabs] = useState<AppTab[]>([]);
   const [repo, setRepo] = useState(getRepoNameFromStorage());
-  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>();
+  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>(new Set(""));
 
   const getTabs = useCallback(async () => {
     const tabs = await chrome.tabs.query({
@@ -17,13 +17,19 @@ const Popup = () => {
     }) as AppTab[];
     console.log({ tabs });
     const filteredTabs = tabs.filter((tab: AppTab) => {
-      if (!repo) {
-        return true;
-      }
+      console.log(uniqueUrls);
       if(uniqueUrls!.has(tab.url!)){
         return false;
       }
+      setUniqueUrls(uniqueUrls.add(tab.url!));
+      return true;
+    })
+    .filter((tab: AppTab) => {
+      if (!repo) {
+        return true;
+      }
       setUniqueUrls(new Set<string>(uniqueUrls!.add(tab.url!)));
+      console.log(`unique urls are: ${uniqueUrls}`)
       return tab.url!.toLowerCase().includes(repo.toLowerCase());
     }).map(tabItem => ({
       ...tabItem,

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -9,6 +9,7 @@ import { AppTab } from '../../types/tab.type';
 const Popup = () => {
   const [tabs, setTabs] = useState<AppTab[]>([]);
   const [repo, setRepo] = useState(getRepoNameFromStorage());
+  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>();
 
   const getTabs = useCallback(async () => {
     const tabs = await chrome.tabs.query({
@@ -19,6 +20,10 @@ const Popup = () => {
       if (!repo) {
         return true;
       }
+      if(uniqueUrls!.has(tab.url!)){
+        return false;
+      }
+      setUniqueUrls(new Set<string>(uniqueUrls!.add(tab.url!)));
       return tab.url!.toLowerCase().includes(repo.toLowerCase());
     }).map(tabItem => ({
       ...tabItem,
@@ -29,7 +34,7 @@ const Popup = () => {
     }
     setTabs(filteredTabs);
     return filteredTabs;
-  }, [repo]);
+  }, [repo, uniqueUrls]);
 
   const sendActionToTabs = (action: any) => {
     tabs.filter(tabItem => (tabItem.isSelected)).forEach(tabItem => {

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -9,19 +9,19 @@ import { AppTab } from '../../types/tab.type';
 const Popup = () => {
   const [tabs, setTabs] = useState<AppTab[]>([]);
   const [repo, setRepo] = useState(getRepoNameFromStorage());
-  const [uniqueUrls, setUniqueUrls] = useState<Set<string>>(new Set());
 
   const getTabs = useCallback(async () => {
     const tabs = await chrome.tabs.query({
       url: ['https://github.com/*/pull/*/files'],
     }) as AppTab[];
     console.log({ tabs });
+    const uniqueUrls = new Set<string>();
     const filteredTabs = tabs
     .filter((tab: AppTab) => {
       if(uniqueUrls && uniqueUrls.has(tab.url!)){
         return false;
       }
-      setUniqueUrls(uniqueUrls.add(tab.url!));
+      uniqueUrls.add(tab.url!);
       if (!repo) {
         return true;
       }
@@ -35,7 +35,7 @@ const Popup = () => {
     }
     setTabs(filteredTabs);
     return filteredTabs;
-  }, [repo, uniqueUrls]);
+  }, [repo]);
 
   const sendActionToTabs = (action: any) => {
     tabs.filter(tabItem => (tabItem.isSelected)).forEach(tabItem => {


### PR DESCRIPTION
Added functionality to the filter in Popup.tsx in which the tabs are filtered based on url. Currently adding urls to a Set to communicate uniqueness and set is a bit faster at checking whether it contains the element, but there might be better solutions. Refresh will not refresh all open tabs this way, naturally, only the first.